### PR TITLE
Fix on Routersploit menu

### DIFF
--- a/Toolss.py
+++ b/Toolss.py
@@ -434,6 +434,7 @@ while loop:
             menu()
         else:
             break
+    elif what == "19":
             os.system("pkg update -y")
             os.system("pkg install -y git")
             os.system("pkg install -y python2")


### PR DESCRIPTION
The Routersploit installation menu was broken.
I added the necessary elif what == "18": line